### PR TITLE
Global og:image fix for pages

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -26,14 +26,15 @@ site, this is the place to do it.
 {% assign description = site.description %}
 {% assign ogimage = false %}
 
+{% if page.ogimage %}
+  {% assign ogimage = site.baseurl | append: page.ogimage  %}
+{% endif %} 
 {% if page.url == "/more-about-shared-services/" %}
   {% assign ogtitle = "What are Shared Services? - Learn about the Federal Government's Shared Services efforts" %}
   {% assign description = "A 3-part approach to delivering on the Federal government's vision for shared services." %}
   {% assign ogimage = "https://ussm.gsa.gov/assets/images/fibf/SM-WhatAreSharedServices600x300.png" %}
 {% elsif page.url contains "fibf" %}
   {% assign ogimage = "https://ussm.gsa.gov/assets/images/fibf/business-standards-website-icons-large.png" %}
-{% elsif page.url contains "ssgb" %}
-  {% assign ogimage = "https://ussm.gsa.gov/assets/images/governance/og-social-governance.webp" %}
 {% endif %}
 
 {% if page.url contains "video-center" and page.layout contains "base" %}
@@ -145,9 +146,6 @@ site, this is the place to do it.
     <meta name="twitter:image" content="{{ogimage}}" />
     <meta name="twitter:description" content="{{ogdescription}}" />
     {% else %}
-    {% if ogimage %}
-    <meta property="og:image" content="{{ogimage}}">
-    {% endif %}
     <meta name="twitter:title" content="{{title | slice: 0, 59}}" />
     <!-- <meta name="twitter:image" content="https://ussm.gsa.gov/assets/images/fibf/business-standards-website-icons-large.png"> -->
     <meta name="twitter:description" content="" />

--- a/_pages/governance/governance-board.md
+++ b/_pages/governance/governance-board.md
@@ -2,6 +2,7 @@
 title: Shared Services Governance Board
 layout: governance/council
 permalink: /ssgb/
+ogimage: /assets/images/governance/og-social-governance.webp
 ---
 
 The Shared Services Governance Board (SSGB) is a cross-council Board of agency executives from each of the Federal Executive Councils. The Board serves as the agency voice in making recommendations to the Office of Management and Budget (OMB) on opportunities to identify shared agency needs for technologies and services that will advance management priorities and advise on their implementation. The SSGB also serves as an escalation point for the Business Standards Council to resolve cross-functional inconsistencies in the creation of data and business standards and to propose resolutions for consideration by OMB policy officials. Membership includes executives from across the Federal enterprise to provide a broad perspective on opportunities, concerns, and policies related to agency adoption and use.


### PR DESCRIPTION
**TODO**

Check if og:image fix works on different pages within the site. Simplify og:image declarations in meta.html template.