### PR TITLE
Ecasogp 12279

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -211,7 +211,7 @@ primary_navigation:
           permalink: /fibf-travel/
           show_in_menu: true
           show_in_footer: false
-        - text: 'Initiating'
+        - text: 'Initiating:'
           type: 'divider'
           show_in_menu: true
           show_in_footer: false

--- a/_config.yml
+++ b/_config.yml
@@ -211,10 +211,6 @@ primary_navigation:
           permalink: /fibf-travel/
           show_in_menu: true
           show_in_footer: false
-        - text: ''
-          permalink: 
-          show_in_menu: true
-          show_in_footer: false
         - text: 'Initiating'
           type: 'divider'
           show_in_menu: true

--- a/_config.yml
+++ b/_config.yml
@@ -114,16 +114,8 @@ primary_navigation:
           permalink: /fibf-ERM/
           show_in_menu: true
           show_in_footer: false
-        - text: 'Federal Sector Equal Employment Opportunity Services'
-          permalink: /fibf-eeo/
-          show_in_menu: true
-          show_in_footer: false
         - text: 'Financial Management'
           permalink: /fibf-fm/
-          show_in_menu: true
-          show_in_footer: false
-        - text: 'Freedom of Information Act (FOIA) Services'
-          permalink: /fibf-foia/
           show_in_menu: true
           show_in_footer: false
         - text: 'Grants Management'
@@ -211,6 +203,36 @@ primary_navigation:
           link: true
           external: false
           sub: true
+        - text: 'Real Property Management'
+          permalink: /fibf-RPM/
+          show_in_menu: true
+          show_in_footer: false
+        - text: 'Travel and Expense Management'
+          permalink: /fibf-travel/
+          show_in_menu: true
+          show_in_footer: false
+        - text: ''
+          permalink: 
+          show_in_menu: true
+          show_in_footer: false
+        - text: 'Initiating'
+          type: 'divider'
+          show_in_menu: true
+          show_in_footer: false
+          style:
+            text-align: 'center'
+            font-weight: 'bold'
+            color: '#555'
+            margin: '20px 0'
+            border-top: '1px solid #ccc'
+        - text: 'Federal Sector Equal Employment Opportunity Services'
+          permalink: /fibf-eeo/
+          show_in_menu: true
+          show_in_footer: false
+        - text: 'Freedom of Information Act (FOIA) Services'
+          permalink: /fibf-foia/
+          show_in_menu: true
+          show_in_footer: false
         - text: 'Information Technology Services'
           permalink: /fibf-its/
           show_in_menu: true
@@ -219,16 +241,8 @@ primary_navigation:
           permalink: /fibf-mom/
           show_in_menu: true
           show_in_footer: false
-        - text: 'Real Property Management'
-          permalink: /fibf-RPM/
-          show_in_menu: true
-          show_in_footer: false
         - text: 'Regulation Management'
           permalink: /fibf-rm/
-          show_in_menu: true
-          show_in_footer: false
-        - text: 'Travel and Expense Management'
-          permalink: /fibf-travel/
           show_in_menu: true
           show_in_footer: false
     - text: 'Modernization'

--- a/_includes/side-nav.html
+++ b/_includes/side-nav.html
@@ -104,18 +104,6 @@ where we provide an easy way to manage your navigation system
                         </li>
 
                         <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
-                            <a style="outline:none"
-                               class="usa-nav__link{% if page.title == 'Federal Sector Equal Employment Opportunity Services' %} usa-current-1{% endif %}"
-                               href="{{site.baseurl}}/fibf-eeo/">
-                                <div class="image-txt-container">
-                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/equals.svg" class="sidebar-logo"
-                                         alt="Federal Sector Equal Employment Opportunity Services Icon"></div>
-                                    <span>Federal Sector Equal Employment Opportunity Services</span>
-                                </div>
-                            </a>
-                        </li>
-
-                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
                             <a class="usa-nav__link{% if page.title == 'Financial Management' %} usa-current-1{% endif %}"
                                href="{{site.baseurl}}/fibf-fm/" style="outline:none">
                                 <div class="image-txt-container ">
@@ -125,18 +113,6 @@ where we provide an easy way to manage your navigation system
                             </span>
                                 </div>
 
-                            </a>
-                        </li>
-
-                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
-                            <a style="outline:none"
-                               class="usa-nav__link{% if page.permalink contains 'fibf-foia' %} usa-current-1{% endif %}"
-                               href="{{site.baseurl}}/fibf-foia/">
-                                <div class="image-txt-container">
-                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/foia.svg" class="sidebar-logo"
-                                         alt="Freedom of Information Act (FOIA) Services Icon"></div>
-                                    <span>Freedom of Information Act (FOIA) Services</span>
-                                </div>
                             </a>
                         </li>
 
@@ -322,30 +298,7 @@ where we provide an easy way to manage your navigation system
 
                         </li>
 
-                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
-                            <a style="outline:none"
-                               class="usa-nav__link{% if page.permalink contains 'fibf-its' %} usa-current-1{% endif %}"
-                               href="{{site.baseurl}}/fibf-its/">
-                                <div class="image-txt-container">
-                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/it.svg" class="sidebar-logo"
-                                         alt="Information Technology Services Icon"></div>
-                                    <span>Information Technology Services</span>
-                                </div>
-                            </a>
-                        </li>
-
-
-                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
-                            <a style="outline:none"
-                               class="usa-nav__link{% if page.permalink contains 'fibf-mom' %} usa-current-1{% endif %}"
-                               href="{{site.baseurl}}/fibf-mom/">
-                                <div class="image-txt-container">
-                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/mail.svg" class="sidebar-logo"
-                                         alt="mail icon white"></div>
-                                    <span>Mail Operations Management</span>
-                                </div>
-                            </a>
-                        </li>
+                        
 
                         <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
                             <a style="outline:none"
@@ -358,17 +311,6 @@ where we provide an easy way to manage your navigation system
                                 </div>
                             </a>
                         </li>
-                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
-                            <a style="outline:none"
-                               class="usa-nav__link{% if page.permalink contains 'fibf-rm' %} usa-current-1{% endif %}"
-                               href="{{site.baseurl}}/fibf-rm/">
-                                <div class="image-txt-container">
-                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/regulation.svg" class="sidebar-logo"
-                                         alt="Regulation Icon"></div>
-                                    <span>Regulation Management</span>
-                                </div>
-                            </a>
-                        </li>
 
                         <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
                             <a style="outline:none"
@@ -378,6 +320,73 @@ where we provide an easy way to manage your navigation system
                                     <div class="img-wrap"><img src="../assets/images/fibf/icons/plane.svg" class="sidebar-logo"
                                          alt="Plane Icon"></div>
                                     <span>Travel and Expense Management</span>
+                                </div>
+                            </a>
+                        </li>
+                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
+                            <a style="outline:none"
+                               class="usa-nav__link{% if page.permalink contains 'fibf-travel' %} usa-current-1{% endif %}"
+                               >
+                                <div class="image-txt-container">
+                                    <div class="img-wrap"></div>
+                                    <span>Initiating:</span>
+                                </div>
+                            </a>
+                        </li>
+                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
+                            <a style="outline:none"
+                               class="usa-nav__link{% if page.title == 'Federal Sector Equal Employment Opportunity Services' %} usa-current-1{% endif %}"
+                               href="{{site.baseurl}}/fibf-eeo/">
+                                <div class="image-txt-container">
+                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/equals.svg" class="sidebar-logo"
+                                         alt="Federal Sector Equal Employment Opportunity Services Icon"></div>
+                                    <span>Federal Sector Equal Employment Opportunity Services</span>
+                                </div>
+                            </a>
+                        </li>
+                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
+                            <a style="outline:none"
+                               class="usa-nav__link{% if page.permalink contains 'fibf-foia' %} usa-current-1{% endif %}"
+                               href="{{site.baseurl}}/fibf-foia/">
+                                <div class="image-txt-container">
+                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/foia.svg" class="sidebar-logo"
+                                         alt="Freedom of Information Act (FOIA) Services Icon"></div>
+                                    <span>Freedom of Information Act (FOIA) Services</span>
+                                </div>
+                            </a>
+                        </li>
+
+                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
+                            <a style="outline:none"
+                               class="usa-nav__link{% if page.permalink contains 'fibf-its' %} usa-current-1{% endif %}"
+                               href="{{site.baseurl}}/fibf-its/">
+                                <div class="image-txt-container">
+                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/it.svg" class="sidebar-logo"
+                                         alt="Information Technology Services Icon"></div>
+                                    <span>Information Technology Services</span>
+                                </div>
+                            </a>
+                        </li>
+
+                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
+                            <a style="outline:none"
+                               class="usa-nav__link{% if page.permalink contains 'fibf-mom' %} usa-current-1{% endif %}"
+                               href="{{site.baseurl}}/fibf-mom/">
+                                <div class="image-txt-container">
+                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/mail.svg" class="sidebar-logo"
+                                         alt="mail icon white"></div>
+                                    <span>Mail Operations Management</span>
+                                </div>
+                            </a>
+                        </li>
+                        <li class="usa-sidenav__item bs" style="margin-bottom: 5px;">
+                            <a style="outline:none"
+                               class="usa-nav__link{% if page.permalink contains 'fibf-rm' %} usa-current-1{% endif %}"
+                               href="{{site.baseurl}}/fibf-rm/">
+                                <div class="image-txt-container">
+                                    <div class="img-wrap"><img src="../assets/images/fibf/icons/regulation.svg" class="sidebar-logo"
+                                         alt="Regulation Icon"></div>
+                                    <span>Regulation Management</span>
                                 </div>
                             </a>
                         </li>


### PR DESCRIPTION
…page and the 'Data & Business Standards' drop down, as per ECASOGP-12279

Added an 'Initiating' sect of the _Data & Business Standards _ dropdown, as well as the left side bar _Business Standard Home _Page_._

Please evaluate these changes under this **preview link:**
https://federalist-4be496a3-cca3-4187-b4d4-c3d573ae3139.sites.pages.cloud.gov/preview/gsa/ussm/ECASOGP-12279/

Here is the story for context - https://cm-jira.usa.gov/browse/ECASOGP-12279

With the following description - 



The Business Standards Menu option on the left-hand side vertical menu for Business Standards as well in the drop-down menu should be divided by "Initiating".
The menu options to be displayed below the initiating menu option should be as below:




Initiating

Federal Sector EEO
Freedom of Information Act
Information Technology 
Mail Management
Regulation Management





