### PR TITLE
Updated rack 2.2.10 -> 2.2.13 to fix High and medium vulnerabilities …

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       forwardable-extended (~> 2.6)
     public_suffix (6.0.1)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.13)
     rainbow (3.1.1)
     rake (13.2.1)
     rb-fsevent (0.11.2)


### PR DESCRIPTION
Updated rack 2.2.10 -> 2.2.13 to fix High and medium vulnerabilities detected by Dependabot. [Preview Link](https://federalist-4be496a3-cca3-4187-b4d4-c3d573ae3139.sites.pages.cloud.gov/preview/gsa/ussm/RITM1319020/)