### PR TITLE
Potential fix for code scanning alert no. 15: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/m3.js
+++ b/assets/js/m3.js
@@ -55,11 +55,15 @@ document.addEventListener("DOMContentLoaded", function () {
         thumbnail.addEventListener("click", function (event) {
             event.preventDefault();
             let newSrc = this.getAttribute("data-video-src");
-            
-            if (!newSrc.includes("autoplay=1")) {
-                newSrc = newSrc.includes("?") ? `${newSrc}&autoplay=1` : `${newSrc}?autoplay=1`;
+            try {
+                let url = new URL(newSrc, window.location.origin);
+                if (!url.searchParams.has("autoplay")) {
+                    url.searchParams.append("autoplay", "1");
+                }
+                mainVideo.setAttribute("src", url.toString());
+            } catch (e) {
+                console.error("Invalid video URL:", newSrc);
             }
-            mainVideo.setAttribute("src", newSrc);
             let figcaption = this.parentElement.querySelector("figcaption");
             if (figcaption && videoTitle) {
                 videoTitle.innerHTML = figcaption.innerHTML;


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/USSM/security/code-scanning/15](https://github.com/GSA/USSM/security/code-scanning/15)

To fix the problem, we need to ensure that the `newSrc` value is properly sanitized before being used as the `src` attribute of the `mainVideo` element. One way to achieve this is by using a URL parser to validate and sanitize the URL. This will help prevent any malicious content from being executed.

We will:
1. Parse the `newSrc` value using the `URL` constructor to ensure it is a valid URL.
2. Extract and modify the query parameters as needed.
3. Set the sanitized URL as the `src` attribute of the `mainVideo` element.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
