### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -1649,6 +1649,21 @@
 
             image = $imgsToLoad.first();
             imageSource = image.attr('data-lazy');
+
+            // Sanitize the imageSource to ensure it is a valid URL
+            var isValidUrl = function (url) {
+                try {
+                    var parsedUrl = new URL(url, window.location.origin);
+                    return parsedUrl.protocol === "http:" || parsedUrl.protocol === "https:";
+                } catch (e) {
+                    return false;
+                }
+            };
+
+            if (!isValidUrl(imageSource)) {
+                console.warn("Invalid data-lazy URL:", imageSource);
+                return;
+            }
             imageToLoad = document.createElement('img');
 
             imageToLoad.onload = function () {


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/USSM/security/code-scanning/8](https://github.com/GSA/USSM/security/code-scanning/8)

To fix the issue, we need to ensure that the value of `imageSource` is sanitized before it is used to set the `src` attribute of the `img` element. A simple and effective way to do this is to validate the `imageSource` value to ensure it is a well-formed and trusted URL. This can be achieved using a regular expression or a URL parser to check the format of the URL. If the value is not valid, it should be ignored or replaced with a default safe value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
