### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -14,7 +14,7 @@
  Issues: http://github.com/kenwheeler/slick/issues
 
  */
-/* global window, document, define, jQuery, setInterval, clearInterval */
+/* global window, document, define, jQuery, setInterval, clearInterval, DOMPurify */
 (function (factory) {
     'use strict';
     if (typeof define === 'function' && define.amd) {
@@ -1649,6 +1649,9 @@
 
             image = $imgsToLoad.first();
             imageSource = image.attr('data-lazy');
+
+            // Sanitize the imageSource to ensure it is safe
+            imageSource = DOMPurify.sanitize(imageSource, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
 
             // Sanitize the imageSource to ensure it is a valid URL
             var isValidUrl = function (url) {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@uswds/uswds": "3.8.1",
     "dot-prop": "^5.3.0",
-    "uswds": "~2.11.0"
+    "uswds": "~2.11.0",
+    "dompurify": "^3.2.6"
   },
   "devDependencies": {
     "rimraf": "^3.0.2"


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/USSM/security/code-scanning/8](https://github.com/GSA/USSM/security/code-scanning/8)

To fix the issue, we need to ensure that the `imageSource` is sanitized before being used in the `src` attribute of the `imageToLoad` element. This can be achieved by escaping any potentially dangerous characters in the `imageSource` or by using a library that ensures safe handling of URLs. Additionally, we should ensure that the `isValidUrl` function is robust and accounts for edge cases.

The best approach is to use a trusted library like `DOMPurify` to sanitize the `imageSource` before assigning it to `imageToLoad.src`. This ensures that even if the `data-lazy` attribute contains malicious content, it will be sanitized and rendered safe.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
