### PR TITLE
Potential fix for code scanning alert no. 6: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/slick.js
+++ b/assets/js/slick.js
@@ -1459,7 +1459,7 @@
             $('img[data-lazy]', imagesScope).each(function () {
 
                 var image = $(this),
-                    imageSource = $(this).attr('data-lazy'),
+                    imageSource = DOMPurify.sanitize($(this).attr('data-lazy')),
                     imageToLoad = document.createElement('img');
 
                 imageToLoad.onload = function () {


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/USSM/security/code-scanning/6](https://github.com/GSA/USSM/security/code-scanning/6)

To fix the issue, the value of the `data-lazy` attribute should be sanitized or validated before being used as the `src` attribute of the dynamically created `img` element. A well-known library like `DOMPurify` can be used to sanitize the value, ensuring that it does not contain malicious content. Alternatively, a custom validation function can be implemented to allow only safe URLs.

The best approach in this case is to use `DOMPurify` to sanitize the `imageSource` value. This ensures that the value is safe to use without introducing custom validation logic, which might be error-prone.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
