### PR TITLE
Potential fix for code scanning alert no. 10: Unsafe jQuery plugin

### DIFF
--- a/assets/js/magnific-popup.js
+++ b/assets/js/magnific-popup.js
@@ -353,7 +353,7 @@
             $('html').css(windowStyles);
 
             // add everything to DOM
-            mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo || $(document.body) );
+            mfp.bgOverlay.add(mfp.wrap).prependTo( mfp.st.prependTo ? $(document).find(mfp.st.prependTo) : $(document.body) );
 
             // Save last focused element
             mfp._lastFocusedEl = document.activeElement;


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/USSM/security/code-scanning/10](https://github.com/GSA/USSM/security/code-scanning/10)

To fix the problem, we need to ensure that the `prependTo` option is always treated as a CSS selector and not as HTML. This can be achieved by using the `jQuery.find` method, which interprets the input as a CSS selector. We will modify the code to use `jQuery.find` instead of directly using the `prependTo` property.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
