### PR TITLE
Potential fix for code scanning alert no. 16: Unsafe jQuery plugin

### DIFF
--- a/assets/js/magnific-popup.js
+++ b/assets/js/magnific-popup.js
@@ -87,10 +87,27 @@
                 }
             }
         },
+        // SECURITY: The closeMarkup option must NEVER include unsanitized user input, as it is interpreted as HTML.
+        //           If you allow user input to influence closeMarkup, you risk XSS vulnerabilities.
         _getCloseBtn = function(type) {
             if(type !== _currPopupType || !mfp.currTemplate.closeBtn) {
+                // Construct close button safely:
                 const safeTitle = $('<div>').text(mfp.st.tClose).html();
-                mfp.currTemplate.closeBtn = $(mfp.st.closeMarkup.replace('%title%', safeTitle));
+                // Only allow default markup (do not interpret user-supplied HTML).
+                if (
+                    mfp.st.closeMarkup &&
+                    mfp.st.closeMarkup === $.magnificPopup.defaults.closeMarkup
+                ) {
+                    mfp.currTemplate.closeBtn = $(
+                        mfp.st.closeMarkup.replace('%title%', safeTitle)
+                    );
+                } else {
+                    // If custom markup is supplied, document risk and escape output
+                    // WARNING: Custom closeMarkup must be trusted and properly sanitized
+                    mfp.currTemplate.closeBtn = $(
+                        $('<div>').html(mfp.st.closeMarkup.replace('%title%', safeTitle)).text()
+                    );
+                }
                 _currPopupType = type;
             }
             return mfp.currTemplate.closeBtn;


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/USSM/security/code-scanning/16](https://github.com/GSA/USSM/security/code-scanning/16)

To mitigate the XSS risk, the plugin must ensure that `closeMarkup` is not interpreted as HTML when supplied as a string. The best fix is to document in the code and/or plugin documentation that `closeMarkup` must *never* contain unsanitized or user-controlled input; it should only contain trusted markup from the developer. Furthermore, you can restrict how jQuery interprets the string by *not* injecting it directly into `$()` if you don't intend to allow custom HTML.

- **Recommended fix:**  
  - If the intention is to only support customization of text content (the `%title%`), use a DOM construction approach instead of injecting HTML via `$()`.  
  - If custom markup is intended, add strong documentation indicating `closeMarkup` must not include unsanitized input.  
  - Alternatively, only allow a known-safe string for `closeMarkup`, or strip unsafe tags (e.g., using a library like DOMPurify).  
  - In the context of the file, update the code constructing the close button to avoid unsafe HTML injection, e.g., by creating the element programmatically, or at least escaping any variables interpolated.

For this file, update line 93 to avoid passing arbitrary HTML from `closeMarkup` directly to `$()`. One safe approach is to only inject the escaped title as text and construct the button markup programmatically.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
