### PR TITLE
Potential fix for code scanning alert no. 17: DOM text reinterpreted as HTML

### DIFF
--- a/assets/js/magnific-popup.js
+++ b/assets/js/magnific-popup.js
@@ -105,7 +105,7 @@
                     // If custom markup is supplied, document risk and escape output
                     // WARNING: Custom closeMarkup must be trusted and properly sanitized
                     mfp.currTemplate.closeBtn = $(
-                        $('<div>').html(mfp.st.closeMarkup.replace('%title%', safeTitle)).text()
+                        $('<div>').text(mfp.st.closeMarkup.replace('%title%', safeTitle)).html()
                     );
                 }
                 _currPopupType = type;


### PR DESCRIPTION
Potential fix for [https://github.com/GSA/USSM/security/code-scanning/17](https://github.com/GSA/USSM/security/code-scanning/17)

To fix the issue, we must prevent potentially unsafe HTML in `mfp.st.closeMarkup` from being reinterpreted (i.e., output unescaped into the DOM). The safest approach is:

- Only allow default markup, which is trusted and safe, to be inserted as HTML.
- For custom markup, ensure that output is strictly treated as text and **not** injected as HTML.
- In the custom markup branch, rather than reconstructing by creating a DOM node and extracting its `.text()`—(which does a round-trip through the DOM, potentially unescaping HTML)—perform direct output encoding/escaping of strings.  
- The fix involves replacing line 108 with a safer approach: Escape meta-characters from `closeMarkup` before writing them to the DOM or render it as plain text (or, preferably, document that only the default markup should be used).

A common method for escaping HTML is to use a library such as lodash’s `_.escape` or jQuery’s built-in escaping via `$('<div>').text(str).html()`. Since we’re already using jQuery, we should use it directly for safe encoding.

Thus, for custom `closeMarkup`, we should treat it as plain text, not HTML: Replace
```js
$('<div>').html(mfp.st.closeMarkup.replace('%title%', safeTitle)).text()
```
with  
```js
$('<div>').text(mfp.st.closeMarkup.replace('%title%', safeTitle)).html()
```
which safely encodes the markup as text.

This change should be made in the custom `closeMarkup` code branch (lines 107-109).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
